### PR TITLE
Remove redundant writes from methods

### DIFF
--- a/gen/som/method.py
+++ b/gen/som/method.py
@@ -90,6 +90,8 @@ class Method:
             for stmt in split_stmts:
                 helper.add_statement(stmt)
 
+            helper.remove_redundant_writes()
+
             self._helper_methods.append(helper)
             new_helpers.append(helper)
 
@@ -111,6 +113,14 @@ class Method:
 
     def add_statement(self, expression):
         self._statements.append(expression)
+
+    def remove_redundant_writes(self):
+        store = {}
+        without_redundant = []
+        for stmt in self._statements:
+            if not stmt.is_redundant(store, without_redundant):
+                without_redundant.append(stmt)
+        self._statements = without_redundant
 
     def _split_into_helpers_if_needed(self, spec_store):
         if (

--- a/gen/spec_test_gen.py
+++ b/gen/spec_test_gen.py
@@ -246,6 +246,7 @@ class _Specification:
         self._gen_literal_permutations(
             method, processed_lines, [], [], self._test_vars[:]
         )
+        method.remove_redundant_writes()
         return method
 
     def _gen_loop(self, target_class, processed_lines, val_handling, rand):

--- a/tests/test_int_spec.py
+++ b/tests/test_int_spec.py
@@ -186,119 +186,80 @@ def test_add_symmetric(tmp_path):
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 0.
     arg := -1.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 0.
     arg := 333.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 0.
     arg := 0.0.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 0.
     arg := -1.2.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 0.
     arg := 3.3.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    int := -1.
+    arg := 0.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class
   )
 
   helper_testIntAddSymmetricLiteral2 = (
     | int arg |
-    self helper_helper_testIntAddSymmetricLiteral21.
-    self helper_helper_testIntAddSymmetricLiteral22
+    int := -1.
+    arg := -1.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    arg := 333.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    arg := 0.0.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    arg := -1.2.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    arg := 3.3.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    int := 333.
+    arg := 0.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class.
+
+    arg := -1.
+    self expect: int + arg  toEqual:  (arg + int).
+    self expect: int + arg toBeKindOf: arg class
   )
 
   helper_testIntAddSymmetricLiteral3 = (
     | int arg |
-    self helper_helper_testIntAddSymmetricLiteral31.
-    self helper_helper_testIntAddSymmetricLiteral32
-  )
-
-  helper_helper_testIntAddSymmetricLiteral21 = (
-    | int arg |
-    int := 0.
-    arg := 3.3.
-    int := -1.
-    arg := 0.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
-    int := -1.
-    arg := -1.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
-    int := -1.
-    arg := 333.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
-    int := -1.
-    arg := 0.0.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
-    int := -1.
-    arg := -1.2.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class
-  )
-
-  helper_helper_testIntAddSymmetricLiteral22 = (
-    | int arg |
-    int := -1.
-    arg := -1.2.
-    int := -1.
-    arg := 3.3.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class
-  )
-
-  helper_helper_testIntAddSymmetricLiteral31 = (
-    | int arg |
-    int := -1.
-    arg := 3.3.
-    int := 333.
-    arg := 0.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
-    int := 333.
-    arg := -1.
-    self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class.
-
     int := 333.
     arg := 333.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 333.
     arg := 0.0.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class.
 
-    int := 333.
     arg := -1.2.
     self expect: int + arg  toEqual:  (arg + int).
-    self expect: int + arg toBeKindOf: arg class
-  )
+    self expect: int + arg toBeKindOf: arg class.
 
-  helper_helper_testIntAddSymmetricLiteral32 = (
-    | int arg |
-    int := 333.
-    arg := -1.2.
-    int := 333.
     arg := 3.3.
     self expect: int + arg  toEqual:  (arg + int).
     self expect: int + arg toBeKindOf: arg class


### PR DESCRIPTION
The approach is very simple, and consists of two steps:

 - eliminate all writes that set the variable to the same value it already has (as single forward pass)
 - remove all writes which can’t be consumed (a partial backward pass when a new write is added, stops on any non-empty line that’s not a write itself)

This fixes #1.